### PR TITLE
Update the process for getting the ip address

### DIFF
--- a/NodeWurflCloudClient/WurflCloudClient.js
+++ b/NodeWurflCloudClient/WurflCloudClient.js
@@ -152,8 +152,13 @@ WurflCloudClient.prototype = {
 
 	//adding the appropriate HTTP Headers to the request
 	    this.http_request_options['X-Cloud-Client'] = 'WurflCloudClient/NodeJS_'+this.client_version;
-	    var ip = this.http_request.connection.remoteAddress;
-	    var fwd = null;
+	    //var ip = this.http_request.connection.remoteAddress;
+	    //This is the right way to get the ip address if your behind the a proxy server
+	    //So if your facing any problems on heroku this is the way to do it.
+	    var ip = this.http_request.headers['x-forwarded-for'];
+	    
+	    //No need for fwd
+	    /*var fwd = null;
 	    if (typeof this.http_request.headers['x-forwarded-for'] != 'undefined') {
 		fwd = this.http_request.headers['x-forwarded-for'];
 	    }
@@ -162,7 +167,9 @@ WurflCloudClient.prototype = {
 		this.http_request_options['X-Forwarded-For'] = ip.toString() +',' +fwd.toString();
 	    }else{
 		this.http_request_options['X-Forwarded-For'] = ip;
-	    }
+	    }*/
+	    
+	    this.http_request_options['X-Forwarded-For'] = ip;
 	    
 	    if (typeof this.http_request.headers['accept'] != 'undefined'){
 		this.http_request_options['X-Accept'] = this.http_request.headers['accept'];


### PR DESCRIPTION
In your request object there is a property called connection, which is a net.Socket object. The net.Socket object has a property remoteAddress, therefore you should be able to get the IP with this call:

ip = this.http_request.connection.remoteAddress

However, the correct method to get the remote IP, if the server is behind a proxy, is 

ip = this.http_request.headers['x-forwarded-for']
